### PR TITLE
fix: pin nibabel<5.0.0 and numpy<2.0 for compatibility with niftiqa

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,9 @@ requires = [
     'executors',
     'yaxil',
     'matplotlib',
-    'nibabel',
-    'scipy'
+    'nibabel<5.0.0',
+    'scipy',
+    'numpy<2.0'
 ]
 
 test_requirements = [


### PR DESCRIPTION
`boldqc/libexec/niftiqa.py` calls nibabel's NiftiImage.get_data() method, which was deprecated in nibabel 3.0 and removed in nibabel 5.0. Running with nibabel >= 5.0 raises ExpiredDeprecationError and crashes the QC pipeline.

Pinning nibabel below 5.0 introduces a secondary constraint: nibabel 4.x uses numpy.sctypes, which was removed in NumPy 2.0. A NumPy < 2.0 upper bound is therefore also required to keep the environment consistent.