### PR TITLE
reduce XNAT JSESSION creation to one per tandem run

### DIFF
--- a/boldqc/cli/get.py
+++ b/boldqc/cli/get.py
@@ -36,10 +36,10 @@ def do(args):
             if scan_type == 'BOLD':
                 run += 1
                 scans[run]['bold'] = scan_id
-    logger.info(json.dumps(scans, indent=2))
-    for run,scansr in scans.items():
-        logger.info('getting bold run=%s, scan=%s', run, scansr['bold'])
-        get_bold(args, auth, run, scansr['bold'], verbose=args.verbose)
+        logger.info(json.dumps(scans, indent=2))
+        for run,scansr in scans.items():
+            logger.info('getting bold run=%s, scan=%s', run, scansr['bold'])
+            get_bold(args, ses._auth, run, scansr['bold'], verbose=args.verbose)
 
 def get_bold(args, auth, run, scan, verbose=False):
     config = {
@@ -73,6 +73,10 @@ def get_bold(args, auth, run, scan, verbose=False):
         ])
     cmd.extend([
         '--config', '-'
+    ])
+    # pass jsession cookie so YAXIL does not create another one
+    cmd.extend([
+        '--jsession', auth.cookie['JSESSIONID']
     ])
     if verbose:
         cmd.append('--debug')

--- a/boldqc/cli/get.py
+++ b/boldqc/cli/get.py
@@ -74,10 +74,7 @@ def get_bold(args, auth, run, scan, verbose=False):
     cmd.extend([
         '--config', '-'
     ])
-    # pass jsession cookie so YAXIL does not create another one
-    cmd.extend([
-        '--jsession', auth.cookie['JSESSIONID']
-    ])
+    os.environ['XNAT_JSESSION'] = auth.cookie['JSESSIONID']
     if verbose:
         cmd.append('--debug')
     logger.info(sp.list2cmdline(cmd))

--- a/boldqc/cli/process.py
+++ b/boldqc/cli/process.py
@@ -106,5 +106,8 @@ def do(args):
     if args.xnat_upload:
         logger.info('Uploading artifacts to XNAT')
         auth = yaxil.auth2(args.xnat_alias)
-        yaxil.storerest(auth, args.artifacts_dir, 'boldqc-resource')
+        if getattr(args, 'jsession', None):
+            auth = auth._replace(cookie={'JSESSIONID': args.jsession})
+        with yaxil.session(auth) as ses:
+            ses.storerest(args.artifacts_dir, 'boldqc-resource')
 

--- a/boldqc/cli/tandem.py
+++ b/boldqc/cli/tandem.py
@@ -40,25 +40,26 @@ def do(args):
                 run += 1
                 scans[run]['bold'] = scan_id
 
-    subject_label = scan['subject_label']
-    logger.info(json.dumps(scans, indent=2))
+        subject_label = scan['subject_label']
+        logger.info(json.dumps(scans, indent=2))
 
-    for run,scansr in scans.items():
-        if run != args.run:
-            continue
-        logger.info('getting bold run=%s, scan=%s', run, scansr['bold'])
-        boldqc.cli.get.get_bold(
-            args,
-            auth,
-            run,
-            scansr['bold'],
-            verbose=args.verbose
-        )
-        args.run = int(run)
-        args.run = int(run)
-        bids_ses_label = yaxil.bids.legal.sub('', args.label)
-        bids_sub_label = yaxil.bids.legal.sub('', subject_label)
-        args.sub = 'sub-' + bids_sub_label
-        args.ses = 'ses-' + bids_ses_label
-        logger.debug('sub=%s, ses=%s', args.sub, args.ses)
-        boldqc.cli.process.do(args)
+        for run,scansr in scans.items():
+            if run != args.run:
+                continue
+            logger.info('getting bold run=%s, scan=%s', run, scansr['bold'])
+            boldqc.cli.get.get_bold(
+                args,
+                ses._auth,
+                run,
+                scansr['bold'],
+                verbose=args.verbose
+            )
+            args.run = int(run)
+            args.run = int(run)
+            bids_ses_label = yaxil.bids.legal.sub('', args.label)
+            bids_sub_label = yaxil.bids.legal.sub('', subject_label)
+            args.sub = 'sub-' + bids_sub_label
+            args.ses = 'ses-' + bids_ses_label
+            logger.debug('sub=%s, ses=%s', args.sub, args.ses)
+            args.jsession = ses._auth.cookie['JSESSIONID']
+            boldqc.cli.process.do(args)


### PR DESCRIPTION
### Background

XNAT enforces a server-side limit on the number of concurrent active sessions per user. Each call to GET /data/JSESSION occupies a slot until the corresponding DELETE /data/JSESSION is issued. On the main branch, a single boldQC.py tandem invocation creates up to 3 sessions: one in the main process, a second inside the ArcGet.py subprocess that downloads the DICOM data, and a potential third when qa data is pushed back to XNAT.

At scale — where dozens to hundreds of jobs run simultaneously — the peak concurrent session count is N_jobs × 2. This can quickly exhaust the per user XNAT session limit, causing new session creation to fail (HTTP 403/429) and crashing jobs.

### Changes

- `tandem.py`: moved all post-auth work inside the existing `with yaxil.session(auth) as ses:` block; passes `ses._auth` (which carries the live JSESSIONID cookie) to `get_bold()` and sets `args.jsession` before calling `process.do()`.
- `get.py`: moved the download loop inside the session context; passes `ses._auth` to `get_bold()`; forwards the JSESSIONID to `ArcGet.py` via the new `--jsession` flag, preventing it from creating its own session.
- `process.py`: when `args.jsession` is present (i.e., called from tandem), injects the existing cookie into auth before opening the upload session, so no new JSESSION is created for the upload step. When called standalone, a session is created and cleaned up normally.

### Dependencies

This PR depends on yaxil PR #35, which adds the `--jsession` argument to `ArcGet.py` and introduces the `_session_owned` guard in `yaxil.session` that prevents creating a new JSESSION when a cookie is already present. This boldqc branch should not be merged until that yaxil PR is merged and the new yaxil version is available in the environment.